### PR TITLE
Use module name if name not provided

### DIFF
--- a/ember-load-initializers.js
+++ b/ember-load-initializers.js
@@ -13,7 +13,11 @@ define("ember/load-initializers",
         }).forEach(function(moduleName) {
           var module = require(moduleName, null, null, true);
           if (!module) { throw new Error(moduleName + ' must export an initializer.'); }
-          app.initializer(module['default']);
+          var initializer = module['default'];
+          if (!initializer.name) {
+            initializer.name = moduleName.replace(new RegExp(prefix + '/initializers/'), '');
+          }
+          app.initializer(initializer);
         });
       }
     }


### PR DESCRIPTION
This is a convenience so you don't have to write the name property.
