### PR TITLE
Use strict prefix for comparison

### DIFF
--- a/ember-load-initializers.js
+++ b/ember-load-initializers.js
@@ -6,7 +6,7 @@ define("ember/load-initializers",
 
     return {
       'default': function(app, prefix) {
-        var initializersRegExp = new RegExp(prefix + '/initializers');
+        var initializersRegExp = new RegExp('^' + prefix + '/initializers');
 
         Ember.keys(requirejs._eak_seen).filter(function(key) {
           return initializersRegExp.test(key);


### PR DESCRIPTION
Due to the way jshint tests are generated we get modules named `my-app/tests/my-app/initializers/foo.js`. These match the load-initializers regex, get required at runtime, and throw an error because `module` is not defined.

![screen shot 2014-05-25 at 22 03 41](https://cloud.githubusercontent.com/assets/34030/3077986/267278de-e450-11e3-9479-a6c9c9698242.png)

The most practical fix I could think of was to make the prefix stricter. Are there any pitfalls to this?
