### PR TITLE
Only attempt to load each module once.

### DIFF
--- a/ember-load-initializers.js
+++ b/ember-load-initializers.js
@@ -11,6 +11,8 @@ define("ember/load-initializers",
         Ember.keys(requirejs._eak_seen).filter(function(key) {
           return initializersRegExp.test(key);
         }).forEach(function(moduleName) {
+          if (app.initializers[moduleName]) { return; }
+
           var module = require(moduleName, null, null, true);
           if (!module) { throw new Error(moduleName + ' must export an initializer.'); }
           app.initializer(module['default']);


### PR DESCRIPTION
Without this, you cannot import the app more than once if you have initializers, as Ember throws an error if you attempt to add an initializer that has already been registered.
