### PR TITLE
Auto-assign names to initializers if not already set

### DIFF
--- a/ember-load-initializers.js
+++ b/ember-load-initializers.js
@@ -13,7 +13,14 @@ define("ember/load-initializers",
         }).forEach(function(moduleName) {
           var module = require(moduleName, null, null, true);
           if (!module) { throw new Error(moduleName + ' must export an initializer.'); }
-          app.initializer(module['default']);
+
+          var initializer = module['default'];
+          if (!initializer.name) {
+            var initializerName = moduleName.match(/[^\/]+\/?$/)[0];
+            initializer.name = initializerName;
+          }
+
+          app.initializer(initializer);
         });
       }
     }


### PR DESCRIPTION
Feel free to reject if you think `name` should be defined explicitly...
