### PR TITLE
Prevent error when instance-initializers are found on Ember < 1.12.

### DIFF
--- a/ember-load-initializers.js
+++ b/ember-load-initializers.js
@@ -31,10 +31,12 @@ define("ember/load-initializers",
               initializer.name = initializerName;
             }
 
-            app[initializerType](initializer);
+            if (app[initializerType]) {
+              app[initializerType](initializer);
+            }
           });
       }
-    }
+    };
   }
 );
 })();


### PR DESCRIPTION
It is reasonable for an addon to include an instance-initializer to be used when possible (Ember >= 1.12), and handle when it is not used (Ember < 1.12) itself.