### PR TITLE
Avoid double walking of all modules

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -3,17 +3,22 @@ import Ember from 'ember';
 export default function(app, prefix) {
   var regex = new RegExp('^' + prefix + '\/((?:instance-)?initializers)\/');
   var getKeys = (Object.keys || Ember.keys);
+  var moduleNames = getKeys(requirejs._eak_seen);
 
-  getKeys(requirejs._eak_seen).map(function (moduleName) {
-    return {
-      moduleName: moduleName,
-      matches: regex.exec(moduleName)
-    };
-  })
-  .filter(function(dep) {
-    return dep.matches && dep.matches.length === 2;
-  })
-  .forEach(function(dep) {
+  var deps = [];
+  for (var i = 0; i < moduleNames.length; i++) {
+    var moduleName = moduleNames[i];
+    var matches = regex.exec(moduleName);
+
+    if (matches && matches.length === 2) {
+      deps.push({
+        moduleName: moduleName,
+        matches: matches
+      });
+    }
+  }
+
+  deps.forEach(function(dep) {
     var moduleName = dep.moduleName;
 
     var module = require(moduleName, null, null, true);

--- a/addon/index.js
+++ b/addon/index.js
@@ -5,34 +5,24 @@ export default function(app, prefix) {
   var getKeys = (Object.keys || Ember.keys);
   var moduleNames = getKeys(requirejs._eak_seen);
 
-  var deps = [];
   for (var i = 0; i < moduleNames.length; i++) {
     var moduleName = moduleNames[i];
     var matches = regex.exec(moduleName);
 
     if (matches && matches.length === 2) {
-      deps.push({
-        moduleName: moduleName,
-        matches: matches
-      });
+      var module = require(moduleName, null, null, true);
+      if (!module) { throw new Error(moduleName + ' must export an initializer.'); }
+
+      var initializerType = Ember.String.camelize(matches[1].substring(0, matches[1].length - 1));
+      var initializer = module['default'];
+      if (!initializer.name) {
+        var initializerName = moduleName.match(/[^\/]+\/?$/)[0];
+        initializer.name = initializerName;
+      }
+
+      if (app[initializerType]) {
+        app[initializerType](initializer);
+      }
     }
   }
-
-  deps.forEach(function(dep) {
-    var moduleName = dep.moduleName;
-
-    var module = require(moduleName, null, null, true);
-    if (!module) { throw new Error(moduleName + ' must export an initializer.'); }
-
-    var initializerType = Ember.String.camelize(dep.matches[1].substring(0, dep.matches[1].length - 1));
-    var initializer = module['default'];
-    if (!initializer.name) {
-      var initializerName = moduleName.match(/[^\/]+\/?$/)[0];
-      initializer.name = initializerName;
-    }
-
-    if (app[initializerType]) {
-      app[initializerType](initializer);
-    }
-  });
 }


### PR DESCRIPTION
Currently this addon walks all of the modules twice in order to determine the modules that are initializers and instance initializers. We can squash the `map` and `filter` loops into one.

This PR addresses that.

cc: @chadhietala 