### PR TITLE
CI: Enable automatic NPM deployment for tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,12 @@ install:
 
 script:
   - npm test
+
+deploy:
+  provider: npm
+  email: stefan.penner+ember-cli@gmail.com
+  api_key:
+    secure: MW2THQxjL0qd7qdasRXVrc8vPBznsSFpPdB72lQQq6zB81i0EerwdWLt0a1xcM/60jOrP5OZiSQ/kee+657wLbL2Hvz1bS2umzTuqmlIZ9j7dLgdI9rHxx5asafP6MuEN5oHzJtHgFI2IC7E//iPmu1SiXwdWYVPYPU8S6K8YcM=
+  on:
+    tags: true
+    repo: ember-cli/ember-load-initializers


### PR DESCRIPTION
After merging this you no longer have to `npm publish` manually. TravisCI will test all pushed tags and deploy automatically after all tests passed.

/cc @nathanhammond @stefanpenner @rwjblue