### PR TITLE
module-unification - look in src/init

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -23,6 +23,10 @@ function registerInstanceInitializers(app, moduleNames) {
 }
 
 export default function (app, prefix) {
+  var EMBER_MODULE_UNIFICATION = true;
+  if (EMBER_MODULE_UNIFICATION) {
+    prefix = prefix + '/src/init';
+  }
   var initializerPrefix =  prefix + '/initializers/';
   var instanceInitializerPrefix =  prefix + '/instance-initializers/';
   var initializers = [];


### PR DESCRIPTION
@mixonic This changes makes an Ember app lookup initializers in `src/init`. The exported function `loadInitializers` is called from app code in `src/main.js` so we could also change the input there to have the right prefix. A few questions:

 - What's the best way to have the flag set from the ember feature flag?
 - Many apps like the travis app will have addons that add initializers to the app tree. So what we really want, instead of this change, is to call `loadInitializers` twice from the `src/main.js`, for example:

```js
loadInitializers(App, config.modulePrefix);
loadInitializers(App, config.modulePrefix + '/src/init');
```
Another solution is to use both prefixes within this addon so that we can call `loadInitializers` once in the app code.

[Call to `loadInitializers` in partial-app](https://github.com/mixonic/partial-app/blob/master/src/main.js#L16)

Fixes #42 