### PR TITLE
allow colocated test files

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -23,6 +23,10 @@ function registerInstanceInitializers(app, moduleNames) {
   }
 }
 
+function _endsWith(str, suffix) {
+  return str.indexOf(suffix, str.length - suffix.length) !== -1;
+}
+
 export default function (app, prefix) {
   var initializerPrefix =  prefix + '/initializers/';
   var instanceInitializerPrefix =  prefix + '/instance-initializers/';
@@ -34,9 +38,13 @@ export default function (app, prefix) {
   for (var i = 0; i < moduleNames.length; i++) {
     var moduleName = moduleNames[i];
     if (moduleName.lastIndexOf(initializerPrefix, 0) === 0) {
-      initializers.push(moduleName);
+      if (!_endsWith(moduleName, '-test')) {
+        initializers.push(moduleName);
+      }
     } else if (moduleName.lastIndexOf(instanceInitializerPrefix, 0) === 0) {
-      instanceInitializers.push(moduleName);
+      if (!_endsWith(moduleName, '-test')) {
+        instanceInitializers.push(moduleName);
+      }
     }
   }
   registerInitializers(app, initializers);

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "ember-data": "^2.17.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
-    "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.0.0",
     "ember-source": "~3.0.0",

--- a/tests/dummy/app/initializers/foo-test.js
+++ b/tests/dummy/app/initializers/foo-test.js
@@ -1,0 +1,1 @@
+export default {};

--- a/tests/dummy/app/instance-initializers/bar-test.js
+++ b/tests/dummy/app/instance-initializers/bar-test.js
@@ -1,0 +1,1 @@
+export default {};


### PR DESCRIPTION
With module unification, test files can be colocated with initializers. This PR avoids registering initializers and application-initializers which end in `-test`.

This will unblock work on MU blueprints such as https://github.com/emberjs/ember.js/pull/16489#issuecomment-381505216