### PR TITLE
Do not assume global variables are assigned to `self`.

### DIFF
--- a/addon/index.ts
+++ b/addon/index.ts
@@ -1,3 +1,9 @@
+declare global {
+  var requirejs: {
+    _eak_seen: Object;
+  };
+}
+
 import Engine from '@ember/engine';
 import require from 'require';
 
@@ -39,7 +45,7 @@ export default function loadInitializers(app: typeof Engine, prefix: string): vo
   var instanceInitializers = [];
   // this is 2 pass because generally the first pass is the problem
   // and is reduced, and resolveInitializer has potential to deopt
-  var moduleNames = Object.keys(self.requirejs._eak_seen);
+  var moduleNames = Object.keys(requirejs._eak_seen);
   for (var i = 0; i < moduleNames.length; i++) {
     var moduleName = moduleNames[i];
     if (moduleName.lastIndexOf(initializerPrefix, 0) === 0) {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,9 @@
     "release-it-lerna-changelog": "^1.0.3",
     "typescript": "^3.6.3"
   },
+  "resolutions": {
+    "**/engine.io": "~3.3.0"
+  },
   "engines": {
     "node": "6.* || 8.* || >= 10.*"
   },


### PR DESCRIPTION
`requirejs` is a global variable (provided by [loader.js here](https://github.com/ember-cli/loader.js/blob/v4.7.0/lib/loader/loader.js#L1)).  The prior code made the assumption that all global variables are assigned to `self`/`window`, but this is _only_ true in some circumstances. For example, when the entire bundle is evaluated within an IIFE `self.requirejs` is undefined.

Fixes #202