### PR TITLE
Fail explicitly when initializer does not have default export

### DIFF
--- a/addon/index.ts
+++ b/addon/index.ts
@@ -13,6 +13,9 @@ function resolveInitializer(moduleName: string) {
     throw new Error(moduleName + ' must export an initializer.');
   }
   var initializer = module['default'];
+  if (!initializer) {
+    throw new Error(moduleName + ' must have a default export');
+  }
   if (!initializer.name) {
     initializer.name = moduleName.slice(moduleName.lastIndexOf('/') + 1);
   }


### PR DESCRIPTION
This is not the real fix for #277 as @rwjblue points out in that issue, but it will help trace the issue for Embroider-built apps more easily. Since the blueprint in Ember also has this default export, it seems reasonable to hard-error when it's not there (e.g. if someone created the file manually and forgot to add it)