### PR TITLE
Stop using `require` to load initializers, pass the modules instead

### DIFF
--- a/addon/index.ts
+++ b/addon/index.ts
@@ -1,18 +1,11 @@
-declare global {
-  var requirejs: {
-    _eak_seen: Object;
-  };
-}
-
 import Engine from '@ember/engine';
-import require from 'require';
 
-function resolveInitializer(moduleName: string) {
-  var module = require(moduleName, null, null, true);
+function resolveInitializer(moduleName: string, compatModules: any) {
+  let module = compatModules[moduleName];
   if (!module) {
     throw new Error(moduleName + ' must export an initializer.');
   }
-  var initializer = module['default'];
+  let initializer = module['default'];
   if (!initializer) {
     throw new Error(moduleName + ' must have a default export');
   }
@@ -22,15 +15,15 @@ function resolveInitializer(moduleName: string) {
   return initializer;
 }
 
-function registerInitializers(app: typeof Engine, moduleNames: string[]) {
-  for (var i = 0; i < moduleNames.length; i++) {
-    app.initializer(resolveInitializer(moduleNames[i]));
+function registerInitializers(app: typeof Engine, moduleNames: string[], compatModules: any) {
+  for (let i = 0; i < moduleNames.length; i++) {
+    app.initializer(resolveInitializer(moduleNames[i], compatModules));
   }
 }
 
-function registerInstanceInitializers(app: typeof Engine, moduleNames: string[]) {
-  for (var i = 0; i < moduleNames.length; i++) {
-    app.instanceInitializer(resolveInitializer(moduleNames[i]));
+function registerInstanceInitializers(app: typeof Engine, moduleNames: string[], compatModules: any) {
+  for (let i = 0; i < moduleNames.length; i++) {
+    app.instanceInitializer(resolveInitializer(moduleNames[i], compatModules));
   }
 }
 
@@ -41,16 +34,16 @@ function _endsWith(str: string, suffix: string): boolean {
 /**
  * Configure your application as it boots
  */
-export default function loadInitializers(app: typeof Engine, prefix: string): void {
-  var initializerPrefix = prefix + '/initializers/';
-  var instanceInitializerPrefix = prefix + '/instance-initializers/';
-  var initializers = [];
-  var instanceInitializers = [];
+export default function loadInitializers(app: typeof Engine, prefix: string, compatModules: any): void {
+  const initializerPrefix = prefix + '/initializers/';
+  const instanceInitializerPrefix = prefix + '/instance-initializers/';
+  let initializers = [];
+  let instanceInitializers = [];
   // this is 2 pass because generally the first pass is the problem
   // and is reduced, and resolveInitializer has potential to deopt
-  var moduleNames = Object.keys(requirejs._eak_seen);
-  for (var i = 0; i < moduleNames.length; i++) {
-    var moduleName = moduleNames[i];
+  const moduleNames = Object.keys(compatModules);
+  for (let i = 0; i < moduleNames.length; i++) {
+    const moduleName = moduleNames[i];
     if (moduleName.lastIndexOf(initializerPrefix, 0) === 0) {
       if (!_endsWith(moduleName, '-test')) {
         initializers.push(moduleName);
@@ -61,6 +54,6 @@ export default function loadInitializers(app: typeof Engine, prefix: string): vo
       }
     }
   }
-  registerInitializers(app, initializers);
-  registerInstanceInitializers(app, instanceInitializers);
+  registerInitializers(app, initializers, compatModules);
+  registerInstanceInitializers(app, instanceInitializers, compatModules);
 }


### PR DESCRIPTION
📝 This is a draft PR to stop using `require` to load initializers, it proposes an implementation but if we want to merge it at some point we'll also have to clean up the types.

**Context**: This PR was drafted in the context of the Embroider Initiative. At some point, we thought we would need it to support initializers when building with Embroider + Vite. It turns out we didn't have to go that far to get initializers work, but this PR can still be interesting in the context of [Strict ES Module Support RFC](https://github.com/emberjs/rfcs/pull/938).

**How to use**: The idea is to pass the app modules to the `loadInitializers` function directly, with a new argument `compatModules`. The `app.js` file of an Ember app would look like this:

```
// my-ember-app/app/app.js
import compatModules from '@embroider/core/entrypoint';

// Define modules imported from Embroider internals
let d = window.define;
for (const [name, module] of Object.entries(compatModules)) {
  d(name, function () {
    return module;
  });
}

export default class App extends Application { /* modulePrefix = ... */ }

// Pass modules to loadInitializers
loadInitializers(App, config.modulePrefix, compatModules);
```
- See [embroider-build/embroider#2006](https://github.com/embroider-build/embroider/pull/2006) for more details about this 

